### PR TITLE
Add residual discount cleanup and enhance processing logic

### DIFF
--- a/src/Controller/Storefront/Account/AccountController.php
+++ b/src/Controller/Storefront/Account/AccountController.php
@@ -190,7 +190,10 @@ class AccountController extends AbstractStoreFrontController
         $discountLineItem->setDescription('Restkauf Rabatt auf Abonnement');
         $discountLineItem->setGood(false);
         $discountLineItem->setStackable(false);
-        $discountLineItem->setRemovable(false);
+        $discountLineItem->setRemovable(true);
+        $discountLineItem->setPayload([
+            'residualPurchase' => true,
+        ]);
 
         $acknowledgedPaymentPercentage = $this->systemConfigService
             ->get("OsSubscriptions.config.residualPurchaseAcknowledgedPaymentPercentage",


### PR DESCRIPTION
Introduced a method to remove invalid residual discounts from the cart when no residual products are present. Updated discount item behavior to make it removable and added a 'residualPurchase' payload for better tracking.