### PR TITLE
Add return order initiation for subscription orders

### DIFF
--- a/src/Resources/config/routes.xml
+++ b/src/Resources/config/routes.xml
@@ -10,4 +10,11 @@
         <default key="_controller">OsSubscriptions\Controller\Storefront\Account\AccountController::residualPurchase</default>
         <default key="_routeScope"><list><string>storefront</string></list></default>
     </route>
+
+    <route id="frontend.account.os.subscription.order.return"
+           path="/account/os/subscriptions/{subscriptionId}/order/return"
+           methods="POST">
+        <default key="_controller">OsSubscriptions\Controller\Storefront\Account\AccountController::initiateReturnOrderProcess</default>
+        <default key="_routeScope"><list><string>storefront</string></list></default>
+    </route>
 </routes>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -19,8 +19,6 @@
         </service>
 
         <service id="OsSubscriptions\Controller\Storefront\Account\AccountController">
-            <argument type="service"
-                      id="Kiener\MolliePayments\Components\Subscription\Page\Account\SubscriptionPageLoader"/>
             <argument type="service" id="Kiener\MolliePayments\Components\Subscription\SubscriptionManager"/>
             <argument type="service" id="mollie_payments.logger"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>

--- a/src/Resources/views/storefront/page/account/subscriptions/subscription-item.html.twig
+++ b/src/Resources/views/storefront/page/account/subscriptions/subscription-item.html.twig
@@ -14,7 +14,6 @@
 
 {% block page_account_mollie_subscriptions_item_overview %}
     {{ parent() }}
-    {# TODO: implement proper endpoints #}
     <div class="order-wrapper">
         <div class="order-item-header">
             <div class="row flex-wrap">
@@ -30,7 +29,7 @@
                     </form>
                 {% endif %}
 
-                <form action="{{ path('frontend.account.mollie.subscriptions.payment.update', { 'swSubscriptionId': subscription.id }) }}"
+                <form action="{{ path('frontend.account.os.subscription.order.return', { 'subscriptionId': subscription.id }) }}"
                       method="post"
                       data-form-csrf-handler="true"
                       class="col-auto">


### PR DESCRIPTION
Introduced a new endpoint to initiate the return process for subscription orders. Refactored AccountController to streamline dependencies and added logic to update order custom fields during the process. Removed unused SubscriptionPageLoader and cleaned up related references.