### PR TITLE
Feature/stock replacement - borrow stock from "buy" variant

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "os/subscriptions",
   "description": "Sell products as subscriptions",
   "type": "shopware-platform-plugin",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "MIT",
   "autoload": {
     "psr-4": {

--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -27,7 +27,7 @@
             <label lang="de-DE">Prozentsatz welcher für bestehende Zahlungen angerechnet werden soll. (%)</label>
             <helpText>Enter value (in decimal format 80.0)</helpText>
             <helpText lang="de-DE">Wert eingeben (im Dezimalformat 80.0)</helpText>
-            <defaultValue>6</defaultValue>
+            <defaultValue>80</defaultValue>
         </input-field>
     </card>
 
@@ -102,7 +102,7 @@
                     <name>11</name>
                     <name lang="de-DE">11</name>
                 </option>
-                <option>
+                <option selected="true">
                     <id>12</id>
                     <name>12</name>
                     <name lang="de-DE">12</name>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -5,8 +5,15 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="os.subscriptions.logger" class="Monolog\Logger">
-            <factory service="Shopware\Core\Framework\Log\LoggerFactory" method="createRotating"/>
+            <!-- <factory service="Shopware\Core\Framework\Log\LoggerFactory" method="createRotating"/> -->
             <argument type="string">os-subscriptions</argument>
+            <argument type="collection">
+                <argument type="service" id="os.subscriptions.rotatingHandler"/>
+            </argument>
+        </service>
+
+        <service id="os.subscriptions.rotatingHandler" class="Monolog\Handler\RotatingFileHandler">
+            <argument type="string">%kernel.logs_dir%/os-subscriptions-%kernel.environment%.log</argument>
         </service>
 
         <service id="OsSubscriptions\Checkout\Cart\SubscriptionCartProcessor">
@@ -28,6 +35,7 @@
             <argument type="service" id="mollie_subscription.repository"/>
             <argument type="service" id="os.subscriptions.logger" />
             <argument type="service" id="product.repository"/>
+            <argument type="service" id="Shopware\Core\Content\Product\Stock\StockStorage"/>
             <tag name="kernel.event_subscriber"/>
         </service>
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -27,6 +27,7 @@
             <argument type="service" id="Kiener\MolliePayments\Components\Subscription\SubscriptionManager"/>
             <argument type="service" id="mollie_subscription.repository"/>
             <argument type="service" id="os.subscriptions.logger" />
+            <argument type="service" id="product.repository"/>
             <tag name="kernel.event_subscriber"/>
         </service>
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -34,8 +34,6 @@
             <argument type="service" id="Kiener\MolliePayments\Components\Subscription\SubscriptionManager"/>
             <argument type="service" id="mollie_subscription.repository"/>
             <argument type="service" id="os.subscriptions.logger" />
-            <argument type="service" id="product.repository"/>
-            <argument type="service" id="Shopware\Core\Content\Product\Stock\StockStorage"/>
             <tag name="kernel.event_subscriber"/>
         </service>
 
@@ -86,6 +84,15 @@
 
         <service id="OsSubscriptions\Subscriber\RentProductsListingSubscriber">
             <argument type="service" id="product.repository"/>
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
+        <service id="OsSubscriptions\Subscriber\RentOrderTransactionSubscriber">
+            <argument type="service" id="os.subscriptions.logger" />
+            <argument type="service" id="order.repository"/>
+            <argument type="service" id="product.repository"/>
+            <argument type="service" id="state_machine_state.repository"/>
+            <argument type="service" id="order_transaction.repository"/>
             <tag name="kernel.event_subscriber"/>
         </service>
     </services>

--- a/src/Subscriber/MollieSubscriptionHistorySubscriber.php
+++ b/src/Subscriber/MollieSubscriptionHistorySubscriber.php
@@ -12,29 +12,17 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-
 /**
- * Used to decrease the product stock for subscription renewals
+ * Used to decrease the product stock for subscription renewals.
  */
 class MollieSubscriptionHistorySubscriber implements EventSubscriberInterface
 {
-
-    /**
-     * @param EntityRepository $orderRepository
-     * @param AbstractStockStorage $stockStorage
-     * @param LoggerInterface $logger
-     */
     public function __construct(
-        private readonly EntityRepository     $orderRepository,
+        private readonly EntityRepository $orderRepository,
         private readonly AbstractStockStorage $stockStorage,
-        private readonly LoggerInterface      $logger
-    )
-    {
-    }
+        private readonly LoggerInterface $logger
+    ) {}
 
-    /**
-     * @return array
-     */
     public static function getSubscribedEvents(): array
     {
         return [
@@ -42,11 +30,6 @@ class MollieSubscriptionHistorySubscriber implements EventSubscriberInterface
         ];
     }
 
-
-    /**
-     * @param EntityWrittenEvent $event
-     * @return void
-     */
     public function onSubscriptionHistoryWritten(EntityWrittenEvent $event): void
     {
         try {
@@ -56,52 +39,58 @@ class MollieSubscriptionHistorySubscriber implements EventSubscriberInterface
         }
     }
 
-    /**
-     * @param EntityWrittenEvent $entityWrittenEvent
-     * @return void
-     */
     private function handleStockReductionForRenewals(EntityWrittenEvent $entityWrittenEvent)
     {
         $context = $entityWrittenEvent->getContext();
 
         foreach ($entityWrittenEvent->getWriteResults() as $writeResult) {
-            if ($writeResult->getPayload()['comment'] !== 'renewed') {
+            if ('renewed' !== $writeResult->getPayload()['comment']) {
                 continue;
             }
 
-            $subscriptionId = $writeResult->getPayload()["subscriptionId"];
+            $subscriptionId = $writeResult->getPayload()['subscriptionId'];
             $criteria = new Criteria();
             $criteria->addFilter(new EqualsFilter('customFields.mollie_payments.swSubscriptionId', $subscriptionId));
             $criteria->addAssociation('lineItems');
             $order = $this->orderRepository->search($criteria, $context)->first();
 
-            # we have to pay attention that if we have artificially increased the stock
-            # in our OrderConvertedSubscriber, we have to skip this step - as it's already done.
+            if (!$order) {
+                continue;
+            }
+
+            // we have to pay attention that if we have artificially increased the stock
+            // in our OrderConvertedSubscriber, we have to skip this step - as it's already done.
             $customFields = $order->getCustomFields();
-            $stockIncreasedBefore = $customFields["os_subscriptions"]["stock_increased"] ?? false;
+
+            // skip initial orders
+            if (isset($customFields['os_subscriptions']['order_type']) && 'initial' == $customFields['os_subscriptions']['order_type']) {
+                continue;
+            }
+
+            $stockIncreasedBefore = $customFields['os_subscriptions']['stock_increased'] ?? false;
             if ($stockIncreasedBefore) {
-                $customFields["os_subscriptions"]["stock_increased"] = false;
+                $customFields['os_subscriptions']['stock_increased'] = false;
                 $this->orderRepository->update([
                     [
                         'id' => $order->getId(),
                         'customFields' => $customFields,
-                    ]
+                    ],
                 ], $context);
 
-                # do not increase/persist the stock
+                // do not increase/persist the stock
                 continue;
             }
 
-            # we can safely increase/persist the stock
+            // we can safely increase/persist the stock
             foreach ($order->getLineItems() as $lineItem) {
-                if ($lineItem->getType() !== LineItem::PRODUCT_LINE_ITEM_TYPE) {
+                if (LineItem::PRODUCT_LINE_ITEM_TYPE !== $lineItem->getType()) {
                     continue;
                 }
 
                 $quantity = $lineItem->getQuantity();
-                $productStock = $lineItem->getPayload()["stock"];
+                $productStock = $lineItem->getPayload()['stock'];
 
-                # persist the stock storage, so no changes will take effect
+                // persist the stock storage, so no changes will take effect
                 $this->stockStorage->alter(
                     [new StockAlteration($lineItem->getId(), $lineItem->getProductId(), $productStock + $quantity, $productStock)],
                     $context

--- a/src/Subscriber/MollieSubscriptionHistorySubscriber.php
+++ b/src/Subscriber/MollieSubscriptionHistorySubscriber.php
@@ -62,11 +62,16 @@ class MollieSubscriptionHistorySubscriber implements EventSubscriberInterface
             // in our OrderConvertedSubscriber, we have to skip this step - as it's already done.
             $customFields = $order->getCustomFields();
 
-            // skip initial orders
-            if (isset($customFields['os_subscriptions']['order_type']) && 'initial' == $customFields['os_subscriptions']['order_type']) {
+            // REVIEW: should I skip the order if its initial one since it's not a renewal?
+            // skip initial and residual orders
+            if (!isset($customFields['os_subscriptions']['order_type'])
+            or (isset($customFields['os_subscriptions']['order_type']) && 'initial' == $customFields['os_subscriptions']['order_type'])
+            or (isset($customFields['os_subscriptions']['order_type']) && 'residual' == $customFields['os_subscriptions']['order_type'])
+            ) {
                 continue;
             }
 
+            // REVIEW: is this correct?
             $stockIncreasedBefore = $customFields['os_subscriptions']['stock_increased'] ?? false;
             if ($stockIncreasedBefore) {
                 $customFields['os_subscriptions']['stock_increased'] = false;

--- a/src/Subscriber/OrderSubscriber.php
+++ b/src/Subscriber/OrderSubscriber.php
@@ -8,6 +8,8 @@ use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemEntity;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Order\OrderEvents;
+use Shopware\Core\Content\Product\Stock\AbstractStockStorage;
+use Shopware\Core\Content\Product\Stock\StockAlteration;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
@@ -23,6 +25,7 @@ class OrderSubscriber implements EventSubscriberInterface
         private readonly EntityRepository $subscriptionRepository,
         private readonly LoggerInterface $logger,
         private readonly EntityRepository $productRepository,
+        private readonly AbstractStockStorage $stockStorage,
     ) {}
 
     public static function getSubscribedEvents(): array
@@ -48,9 +51,15 @@ class OrderSubscriber implements EventSubscriberInterface
 
                 $this->tagOrder($currentOrder, $event->getContext());
                 $this->cancelAndTagSubscriptionOnResidualPurchase($currentOrder, $event->getContext());
+
+                // check if the ordered products are rentable and out of stock, then borrow stock from the borrow product variant
+                $this->borrowStock($currentOrder, $event->getContext());
             }
         } catch (\Exception $e) {
-            $this->logger->error($e->getMessage());
+            $this->logger->error('ABORTED OrderSubscriber:', [
+                'error' => $e->getMessage(),
+                'line' => $e->getLine(),
+            ]);
         }
     }
 
@@ -178,80 +187,231 @@ class OrderSubscriber implements EventSubscriberInterface
         );
     }
 
-    private function borrowStock(OrderEntity $order)
+    private function borrowStock(OrderEntity $order, $context)
     {
-        $customFields = $order->getCustomFields();
+        try {
+            $this->logger->info('STARTED Borrowing stock: Borrowing stock was called', [
+                'orderId' => $order->getId(),
+            ]);
 
-        if (isset($customFields['os_subscriptions']['order_type']) && 'initial' === $customFields['os_subscriptions']['order_type']) {
-            $lineItems = $order->getLineItems();
+            $orderTransactions = $order->getTransactions();
 
-            foreach ($lineItems as $lineItem) {
-                $lineItemPayload = $lineItem->getPayload();
-                $lineItemStock = $lineItemPayload['stock'];
+            if (empty($orderTransactions)) {
+                $this->logger->info('ABORTED Borrowing stock: No transactions found in order', [
+                    'orderId' => $order->getId(),
+                ]);
 
-                if ($lineItemStock < 1) {
-                    $criteria = new Criteria();
-                    $criteria->addFilter(new EqualsFilter('id', $lineItem->getProductId()));
-                    $product = $this->productRepository->search($criteria, Context::createDefaultContext())->first();
+                return;
+            }
 
-                    if ($product) {
-                        // Perform actions with the product
+            $orderTransactionState = $order->getTransactions()->first()->getStateMachineState()->getTechnicalName();
 
-                        $customFields = $product->getCustomFields();
+            if ('paid' !== $orderTransactionState) {
+                $this->logger->info('ABORTED Borrowing stock: Order not paid yet', [
+                    'orderId' => $order->getId(),
+                    'orderTransactionState' => $orderTransactionState,
+                ]);
 
-                        if (!$customFields or !isset($customFields['mollie_payments_product_subscription_enabled'])) {
-                            return;
+                return;
+            }
+
+            $orderCustomFields = $order->getCustomFields();
+
+            if (isset($orderCustomFields['os_subscriptions']['stock_borrowed'])) {
+                $this->logger->info('ABORTED Borrowing stock 0: Stock was already borrowed', [
+                    'orderId' => $order->getId(),
+                    'orderCustomFields' => $orderCustomFields,
+                ]);
+
+                return;
+            }
+
+            if (isset($orderCustomFields['os_subscriptions']['order_type']) && 'initial' == $orderCustomFields['os_subscriptions']['order_type']) {
+                $lineItems = $order->getLineItems();
+
+                if (!$lineItems) {
+                    $this->logger->info('ABORTED Borrowing stock 1: No line items found in order', [
+                        'orderId' => $order->getId(),
+                        'orderCustomFields' => $orderCustomFields,
+                    ]);
+
+                    return;
+                }
+
+                foreach ($lineItems as $lineItem) {
+                    $lineItemPayload = $lineItem->getPayload();
+
+                    if (!isset($lineItemPayload['stock'])) {
+                        $this->logger->info('ABORTED Borrowing stock 2: No line items payload found in order', [
+                            'orderId' => $order->getId(),
+                            'orderCustomFields' => $orderCustomFields,
+                        ]);
+
+                        return;
+                    }
+
+                    $lineItemStock = $lineItemPayload['stock'];
+
+                    if ($lineItemStock < 1) {
+                        $this->logger->info('CONTINUED Borrowing stock: Line items stock found in order was below 1', [
+                            'orderId' => $order->getId(),
+                            'orderCustomFields' => $orderCustomFields,
+                        ]);
+
+                        $criteria = new Criteria();
+                        $criteria->addFilter(new EqualsFilter('id', $lineItem->getProductId()));
+                        $product = $this->productRepository->search($criteria, $context)->first();
+
+                        if ($product) {
+                            // Perform actions with the product
+
+                            $productCustomFields = $product->getCustomFields();
+
+                            if (!$productCustomFields or !isset($productCustomFields['mollie_payments_product_subscription_enabled'])) {
+                                $this->logger->info('ABORTED Borrowing stock 3: No product custom fields found', [
+                                    'orderId' => $order->getId(),
+                                    'orderCustomFields' => $orderCustomFields,
+                                ]);
+
+                                return;
+                            }
+                            // Check if the product is a subscription product
+                            $isSubscriptionProduct = true === $productCustomFields['mollie_payments_product_subscription_enabled'] ? true : false;
+
+                            if (!$isSubscriptionProduct) {
+                                $this->logger->info('ABORTED Borrowing stock 4: Product is not subscription type', [
+                                    'orderId' => $order->getId(),
+                                    'orderCustomFields' => $orderCustomFields,
+                                ]);
+
+                                return;
+                            }
+
+                            // Check if the product has a borrow product variant
+                            if (!isset($productCustomFields['mollie_payments_product_parent_buy_variant'])) {
+                                $this->logger->info('ABORTED Borrowing stock 5: Product has no borrowing variant', [
+                                    'orderId' => $order->getId(),
+                                    'orderCustomFields' => $orderCustomFields,
+                                ]);
+
+                                return;
+                            }
+
+                            $borrowProductVariantId = $productCustomFields['mollie_payments_product_parent_buy_variant'];
+
+                            if (!$borrowProductVariantId) {
+                                return;
+                            }
+
+                            // search for the borrow product variant
+                            // $context = Context::createDefaultContext();
+                            $criteria = new Criteria([$borrowProductVariantId]);
+                            $criteria->addAssociation('customFields');
+
+                            $productBorrowVariant = $this->productRepository->search($criteria, $context)->first();
+
+                            // Check if the borrow product variant is available on stock
+                            if (!$productBorrowVariant and $productBorrowVariant->getAvailableStock() < 1) {
+                                $this->logger->info('ABORTED Borrowing stock 6: Product borrowing variant doesnt exist or has not enough stock to borrow', [
+                                    'orderId' => $order->getId(),
+                                    'orderCustomFields' => $orderCustomFields,
+                                ]);
+
+                                return false;
+                            }
+
+                            // now swap the product stock like this; substract sthe stock from productBorrowVariant by the line item quantity and add it to the product
+
+                            // $productBorrowVariant->setAvailableStock($productBorrowVariant->getAvailableStock() - $lineItem->getQuantity());
+                            // $productBorrowVariant->setStock($productBorrowVariant->getStock() - $lineItem->getQuantity());
+                            // $product->setAvailableStock($product->getAvailableStock() + $lineItem->getQuantity());
+                            // $product->setStock($product->getStock() + $lineItem->getQuantity());
+
+                            $this->logger->info('PROCESSING Borrowing stock: Reducing stock from borrow product variant', [
+                                'lineItemId' => $lineItem->getId(),
+                                'productId' => $lineItem->getProductId(),
+                                'quantity' => $lineItem->getQuantity(),
+                                'productBorrowVariant' => $productBorrowVariant->getId(),
+                                'newStock' => $productBorrowVariant->getStock() - $lineItem->getQuantity(),
+                                'oldStock' => $productBorrowVariant->getStock(),
+                            ]);
+
+                            $this->logger->info('PROCCESING Borrowing stock: Adding stock to subscription variant', [
+                                'lineItemId' => $lineItem->getId(),
+                                'productId' => $lineItem->getProductId(),
+                                'quantity' => $lineItem->getQuantity(),
+                                'product' => $product->getId(),
+                                'newStock' => $product->getStock() + $lineItem->getQuantity(),
+                                'oldStock' => $product->getStock(),
+                            ]);
+
+                            // Update the product stock
+                            $this->productRepository->update([
+                                [
+                                    'id' => $productBorrowVariant->getId(),
+                                    'availableStock' => $productBorrowVariant->getAvailableStock(),
+                                    'stock' => $productBorrowVariant->getStock(),
+                                ],
+                                [
+                                    'id' => $product->getId(),
+                                    'availableStock' => $product->getAvailableStock(),
+                                    'stock' => $product->getStock(),
+                                ],
+                            ], $context);
+
+                            // borrow from the borrow product variant and add to the product
+                            // $this->stockStorage->alter(
+                            //     [new StockAlteration($lineItem->getId(), $lineItem->getProductId(), $productBorrowVariant->getStock() - $lineItem->getQuantity(), $productBorrowVariant->getStock())],
+                            //     $context
+                            // );
+
+                            $this->logger->info('PROCESSED Borrowing stock: Borrowed stock from borrow product variant');
+
+                            // Update the product stock
+                            // $this->stockStorage->alter(
+                            //     [new StockAlteration($lineItem->getId(), $lineItem->getProductId(), $product->getStock() + $lineItem->getQuantity(), $product->getStock())],
+                            //     $context
+                            // );
+
+                            $this->logger->info('PROCESSED Borrowing stock: Added stock to subscription product variant');
+
+                            $orderCustomFields['os_subscriptions']['stock_borrowed'] = true;
+                            $orderCustomFields['os_subscriptions']['stock_borrowed_from'] = $productBorrowVariant->getId();
+                            $orderCustomFields['os_subscriptions']['stock_borrowed_to'] = $product->getId();
+
+                            $this->orderRepository->update([
+                                [
+                                    'id' => $order->getId(),
+                                    'customFields' => $orderCustomFields,
+                                ],
+                            ], $context);
+
+                            $this->logger->info('PROCESSED Borrowing stock: Added borrowed stock data to order custom fields');
                         }
-                        // Check if the product is a subscription product
-                        $isSubscriptionProduct = true === $customFields['mollie_payments_product_subscription_enabled'] ? true : false;
+                    } else {
+                        $this->logger->info('ABORTED Borrowing stock 7: Line items stock was above 1', [
+                            'orderId' => $order->getId(),
+                            'orderCustomFields' => $orderCustomFields,
+                        ]);
 
-                        if (!$isSubscriptionProduct) {
-                            return;
-                        }
-
-                        // Check if the product has a borrow product variant
-                        if (!isset($customFields['mollie_payments_product_parent_buy_variant'])) {
-                            return;
-                        }
-
-                        $borrowProductVariantId = $customFields['mollie_payments_product_parent_buy_variant'];
-
-                        if (!$borrowProductVariantId) {
-                            return;
-                        }
-
-                        // search for the borrow product variant
-                        $context = Context::createDefaultContext();
-                        $criteria = new Criteria([$borrowProductVariantId]);
-                        $criteria->addAssociation('customFields');
-
-                        $productBorrowVariant = $this->productRepository->search($criteria, $context)->first();
-
-                        // Check if the borrow product variant is available on stock
-                        if ($productBorrowVariant and $productBorrowVariant->getAvailableStock() > 0) {
-                            // make the product purchaseable
-                            return true;
-                        }
-
-                        // now swap the product stock like this; substract sthe stock from productBorrowVariant by the line item quantity and add it to the product
-
-                        $productBorrowVariant->setAvailableStock($productBorrowVariant->getAvailableStock() - $lineItem->getQuantity());
-                        $product->setAvailableStock($product->getAvailableStock() + $lineItem->getQuantity());
-
-                        // Update the product stock
-                        $this->productRepository->update([
-                            [
-                                'id' => $productBorrowVariant->getId(),
-                                'availableStock' => $productBorrowVariant->getAvailableStock(),
-                            ],
-                            [
-                                'id' => $product->getId(),
-                                'availableStock' => $product->getAvailableStock(),
-                            ],
-                        ], $context);
+                        return;
                     }
                 }
             }
+
+            $this->logger->info('ABORTED Borrowing stock 8: Order is not of subscription initial type', [
+                'orderId' => $order,
+                'orderCustomFields' => $orderCustomFields,
+            ]);
+
+            return false;
+        } catch (\Exception $e) {
+            $this->logger->error('ABORTED Borrowing stock 9:', [
+                'orderId' => $order,
+                'orderCustomFields' => $order->getCustomFields(),
+                'error' => $e->getMessage(),
+                'line' => $e->getLine(),
+            ]);
         }
     }
 }

--- a/src/Subscriber/OrderSubscriber.php
+++ b/src/Subscriber/OrderSubscriber.php
@@ -8,8 +8,6 @@ use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemEntity;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Order\OrderEvents;
-use Shopware\Core\Content\Product\Stock\AbstractStockStorage;
-use Shopware\Core\Content\Product\Stock\StockAlteration;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
@@ -24,8 +22,6 @@ class OrderSubscriber implements EventSubscriberInterface
         private readonly SubscriptionManager $subscriptionManager,
         private readonly EntityRepository $subscriptionRepository,
         private readonly LoggerInterface $logger,
-        private readonly EntityRepository $productRepository,
-        private readonly AbstractStockStorage $stockStorage,
     ) {}
 
     public static function getSubscribedEvents(): array
@@ -51,9 +47,6 @@ class OrderSubscriber implements EventSubscriberInterface
 
                 $this->tagOrder($currentOrder, $event->getContext());
                 $this->cancelAndTagSubscriptionOnResidualPurchase($currentOrder, $event->getContext());
-
-                // check if the ordered products are rentable and out of stock, then borrow stock from the borrow product variant
-                $this->borrowStock($currentOrder, $event->getContext());
             }
         } catch (\Exception $e) {
             $this->logger->error('ABORTED OrderSubscriber:', [
@@ -185,233 +178,5 @@ class OrderSubscriber implements EventSubscriberInterface
                 );
             }
         );
-    }
-
-    private function borrowStock(OrderEntity $order, $context)
-    {
-        try {
-            $this->logger->info('STARTED Borrowing stock: Borrowing stock was called', [
-                'orderId' => $order->getId(),
-            ]);
-
-            $orderTransactions = $order->getTransactions();
-
-            if (empty($orderTransactions)) {
-                $this->logger->info('ABORTED Borrowing stock: No transactions found in order', [
-                    'orderId' => $order->getId(),
-                ]);
-
-                return;
-            }
-
-            $orderTransactionState = $order->getTransactions()->first()->getStateMachineState()->getTechnicalName();
-
-            if ('paid' !== $orderTransactionState) {
-                $this->logger->info('ABORTED Borrowing stock: Order not paid yet', [
-                    'orderId' => $order->getId(),
-                    'orderTransactionState' => $orderTransactionState,
-                ]);
-
-                return;
-            }
-
-            $orderCustomFields = $order->getCustomFields();
-
-            if (isset($orderCustomFields['os_subscriptions']['stock_borrowed'])) {
-                $this->logger->info('ABORTED Borrowing stock 0: Stock was already borrowed', [
-                    'orderId' => $order->getId(),
-                    'orderCustomFields' => $orderCustomFields,
-                ]);
-
-                return;
-            }
-
-            if (isset($orderCustomFields['os_subscriptions']['order_type']) && 'initial' == $orderCustomFields['os_subscriptions']['order_type']) {
-                $lineItems = $order->getLineItems();
-
-                if (!$lineItems) {
-                    $this->logger->info('ABORTED Borrowing stock 1: No line items found in order', [
-                        'orderId' => $order->getId(),
-                        'orderCustomFields' => $orderCustomFields,
-                    ]);
-
-                    return;
-                }
-
-                foreach ($lineItems as $lineItem) {
-                    $lineItemPayload = $lineItem->getPayload();
-
-                    if (!isset($lineItemPayload['stock'])) {
-                        $this->logger->info('ABORTED Borrowing stock 2: No line items payload found in order', [
-                            'orderId' => $order->getId(),
-                            'orderCustomFields' => $orderCustomFields,
-                        ]);
-
-                        return;
-                    }
-
-                    $lineItemStock = $lineItemPayload['stock'];
-
-                    if ($lineItemStock < 1) {
-                        $this->logger->info('CONTINUED Borrowing stock: Line items stock found in order was below 1', [
-                            'orderId' => $order->getId(),
-                            'orderCustomFields' => $orderCustomFields,
-                        ]);
-
-                        $criteria = new Criteria();
-                        $criteria->addFilter(new EqualsFilter('id', $lineItem->getProductId()));
-                        $product = $this->productRepository->search($criteria, $context)->first();
-
-                        if ($product) {
-                            // Perform actions with the product
-
-                            $productCustomFields = $product->getCustomFields();
-
-                            if (!$productCustomFields or !isset($productCustomFields['mollie_payments_product_subscription_enabled'])) {
-                                $this->logger->info('ABORTED Borrowing stock 3: No product custom fields found', [
-                                    'orderId' => $order->getId(),
-                                    'orderCustomFields' => $orderCustomFields,
-                                ]);
-
-                                return;
-                            }
-                            // Check if the product is a subscription product
-                            $isSubscriptionProduct = true === $productCustomFields['mollie_payments_product_subscription_enabled'] ? true : false;
-
-                            if (!$isSubscriptionProduct) {
-                                $this->logger->info('ABORTED Borrowing stock 4: Product is not subscription type', [
-                                    'orderId' => $order->getId(),
-                                    'orderCustomFields' => $orderCustomFields,
-                                ]);
-
-                                return;
-                            }
-
-                            // Check if the product has a borrow product variant
-                            if (!isset($productCustomFields['mollie_payments_product_parent_buy_variant'])) {
-                                $this->logger->info('ABORTED Borrowing stock 5: Product has no borrowing variant', [
-                                    'orderId' => $order->getId(),
-                                    'orderCustomFields' => $orderCustomFields,
-                                ]);
-
-                                return;
-                            }
-
-                            $borrowProductVariantId = $productCustomFields['mollie_payments_product_parent_buy_variant'];
-
-                            if (!$borrowProductVariantId) {
-                                return;
-                            }
-
-                            // search for the borrow product variant
-                            // $context = Context::createDefaultContext();
-                            $criteria = new Criteria([$borrowProductVariantId]);
-                            $criteria->addAssociation('customFields');
-
-                            $productBorrowVariant = $this->productRepository->search($criteria, $context)->first();
-
-                            // Check if the borrow product variant is available on stock
-                            if (!$productBorrowVariant and $productBorrowVariant->getAvailableStock() < 1) {
-                                $this->logger->info('ABORTED Borrowing stock 6: Product borrowing variant doesnt exist or has not enough stock to borrow', [
-                                    'orderId' => $order->getId(),
-                                    'orderCustomFields' => $orderCustomFields,
-                                ]);
-
-                                return false;
-                            }
-
-                            // now swap the product stock like this; substract sthe stock from productBorrowVariant by the line item quantity and add it to the product
-
-                            // $productBorrowVariant->setAvailableStock($productBorrowVariant->getAvailableStock() - $lineItem->getQuantity());
-                            // $productBorrowVariant->setStock($productBorrowVariant->getStock() - $lineItem->getQuantity());
-                            // $product->setAvailableStock($product->getAvailableStock() + $lineItem->getQuantity());
-                            // $product->setStock($product->getStock() + $lineItem->getQuantity());
-
-                            $this->logger->info('PROCESSING Borrowing stock: Reducing stock from borrow product variant', [
-                                'lineItemId' => $lineItem->getId(),
-                                'productId' => $lineItem->getProductId(),
-                                'quantity' => $lineItem->getQuantity(),
-                                'productBorrowVariant' => $productBorrowVariant->getId(),
-                                'newStock' => $productBorrowVariant->getStock() - $lineItem->getQuantity(),
-                                'oldStock' => $productBorrowVariant->getStock(),
-                            ]);
-
-                            $this->logger->info('PROCCESING Borrowing stock: Adding stock to subscription variant', [
-                                'lineItemId' => $lineItem->getId(),
-                                'productId' => $lineItem->getProductId(),
-                                'quantity' => $lineItem->getQuantity(),
-                                'product' => $product->getId(),
-                                'newStock' => $product->getStock() + $lineItem->getQuantity(),
-                                'oldStock' => $product->getStock(),
-                            ]);
-
-                            // Update the product stock
-                            $this->productRepository->update([
-                                [
-                                    'id' => $productBorrowVariant->getId(),
-                                    'availableStock' => $productBorrowVariant->getAvailableStock(),
-                                    'stock' => $productBorrowVariant->getStock(),
-                                ],
-                                [
-                                    'id' => $product->getId(),
-                                    'availableStock' => $product->getAvailableStock(),
-                                    'stock' => $product->getStock(),
-                                ],
-                            ], $context);
-
-                            // borrow from the borrow product variant and add to the product
-                            // $this->stockStorage->alter(
-                            //     [new StockAlteration($lineItem->getId(), $lineItem->getProductId(), $productBorrowVariant->getStock() - $lineItem->getQuantity(), $productBorrowVariant->getStock())],
-                            //     $context
-                            // );
-
-                            $this->logger->info('PROCESSED Borrowing stock: Borrowed stock from borrow product variant');
-
-                            // Update the product stock
-                            // $this->stockStorage->alter(
-                            //     [new StockAlteration($lineItem->getId(), $lineItem->getProductId(), $product->getStock() + $lineItem->getQuantity(), $product->getStock())],
-                            //     $context
-                            // );
-
-                            $this->logger->info('PROCESSED Borrowing stock: Added stock to subscription product variant');
-
-                            $orderCustomFields['os_subscriptions']['stock_borrowed'] = true;
-                            $orderCustomFields['os_subscriptions']['stock_borrowed_from'] = $productBorrowVariant->getId();
-                            $orderCustomFields['os_subscriptions']['stock_borrowed_to'] = $product->getId();
-
-                            $this->orderRepository->update([
-                                [
-                                    'id' => $order->getId(),
-                                    'customFields' => $orderCustomFields,
-                                ],
-                            ], $context);
-
-                            $this->logger->info('PROCESSED Borrowing stock: Added borrowed stock data to order custom fields');
-                        }
-                    } else {
-                        $this->logger->info('ABORTED Borrowing stock 7: Line items stock was above 1', [
-                            'orderId' => $order->getId(),
-                            'orderCustomFields' => $orderCustomFields,
-                        ]);
-
-                        return;
-                    }
-                }
-            }
-
-            $this->logger->info('ABORTED Borrowing stock 8: Order is not of subscription initial type', [
-                'orderId' => $order,
-                'orderCustomFields' => $orderCustomFields,
-            ]);
-
-            return false;
-        } catch (\Exception $e) {
-            $this->logger->error('ABORTED Borrowing stock 9:', [
-                'orderId' => $order,
-                'orderCustomFields' => $order->getCustomFields(),
-                'error' => $e->getMessage(),
-                'line' => $e->getLine(),
-            ]);
-        }
     }
 }

--- a/src/Subscriber/RentOrderTransactionSubscriber.php
+++ b/src/Subscriber/RentOrderTransactionSubscriber.php
@@ -1,0 +1,403 @@
+<?php
+
+namespace OsSubscriptions\Subscriber;
+
+use Psr\Log\LoggerInterface;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionDefinition;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStates;
+use Shopware\Core\Checkout\Order\OrderEntity;
+use Shopware\Core\Checkout\Order\OrderEvents;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenEvent;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class RentOrderTransactionSubscriber implements EventSubscriberInterface
+{
+    private $logger;
+    private readonly EntityRepository $orderRepository;
+    private readonly EntityRepository $productRepository;
+    private readonly EntityRepository $stateMachineStateRepository;
+    private readonly EntityRepository $transactionRepository;
+
+    public function __construct(LoggerInterface $logger, EntityRepository $orderRepository, EntityRepository $productRepository, EntityRepository $stateMachineStateRepository, EntityRepository $transactionRepository)
+    {
+        $this->logger = $logger;
+        $this->orderRepository = $orderRepository;
+        $this->productRepository = $productRepository;
+        $this->stateMachineStateRepository = $stateMachineStateRepository;
+        $this->transactionRepository = $transactionRepository;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            OrderEvents::ORDER_TRANSACTION_WRITTEN_EVENT => 'onOrderTransactionWritten',
+        ];
+    }
+
+    public function onOrderTransactionWritten(EntityWrittenEvent $event): void
+    {
+        $results = $event->getWriteResults();
+        $context = $event->getContext();
+
+        foreach ($results as $result) {
+            // check if the event is the type of transaction
+            if ('order_transaction' !== $result->getEntityName()) {
+                continue;
+            }
+
+            $payload = $result->getPayload();
+
+            if (!$payload) {
+                $this->logger->error('Borrow stock: Transaction payload not found, can not continue');
+
+                continue;
+            }
+
+            // $this->logger->info('Transaction payload', ['payload' => $payload]);
+
+            $transactionId = $payload['id'] ?? null;
+            $transactionVersionId = $payload['versionId'] ?? null;
+
+            if (!$transactionId) {
+                $this->logger->error('Borrow stock: Transaction ID not found in payload');
+
+                continue;
+            }
+
+            $criteria = new Criteria();
+            $criteria->addFilter(new EqualsFilter('id', $transactionId));
+
+            $criteria = new Criteria();
+            $criteria->addFilter(new EqualsFilter('id', $transactionId));
+            $criteria->addFilter(new EqualsFilter('versionId', $transactionVersionId));
+            $criteria->addAssociation('order');
+
+            $transaction = $this->transactionRepository->search($criteria, $context)->first();
+
+            if (!$transaction) {
+                $this->logger->error('Borrow stock: Transaction not found', [
+                    'transactionId' => $transactionId,
+                ]);
+
+                continue;
+            }
+
+            // Try again find the state id of the transaction
+            $transactionStateId = $transaction->getStateId();
+
+            if (!$transactionStateId) {
+                $this->logger->error('Borrow stock: Transaction state ID not found in payload 2nd time, aborting!');
+
+                continue;
+            }
+
+            // Add filter for OrderTransactionStateMachine
+            $criteria = new Criteria();
+            $criteria->addFilter(
+                new EqualsFilter('stateMachine.technicalName', \sprintf('%s.state', OrderTransactionDefinition::ENTITY_NAME)),
+                new EqualsAnyFilter('technicalName', [OrderTransactionStates::STATE_PAID, OrderTransactionStates::STATE_PARTIALLY_PAID, OrderTransactionStates::STATE_AUTHORIZED])
+            );
+
+            $defaultTransactionStatesIds = $this->stateMachineStateRepository->searchIds($criteria, $context)->getIds();
+
+            if (!$defaultTransactionStatesIds) {
+                $this->logger->error('ABORTED Borrow stock: Default transaction states not found');
+
+                continue;
+            }
+
+            if (!in_array($transactionStateId, $defaultTransactionStatesIds)) {
+                $this->logger->info('ABORTED Borrow stock: Transaction state is not paid, paid_partially or authorized', [
+                    // 'defaultTransactionStatesIds' => $defaultTransactionStatesIds,
+                    'transactionStateId' => $transactionStateId,
+                ]);
+
+                continue;
+            }
+
+            // get the order ID
+            $orderId = $transaction->getOrderId();
+
+            if (!$orderId) {
+                $this->logger->error('Borrow stock: Order ID not found in transaction', [
+                    'transactionId' => $transactionId,
+                ]);
+
+                continue;
+            }
+
+            $borrowStock = $this->borrowStock($orderId, $context);
+
+            if ($borrowStock) {
+                $this->logger->info('Borrow stock: Stock borrowing performed successfully', [
+                    'orderId' => $orderId,
+                ]);
+            } else {
+                $this->logger->info('Borrow stock: Stock borrowing not performed', [
+                    'orderId' => $orderId,
+                ]);
+            }
+        }
+    }
+
+    private function borrowStock($orderId, $context): bool
+    {
+        try {
+            $this->logger->info('INIT Borrowing stock: Borrowing stock was initiated', [
+                'orderId' => $orderId,
+            ]);
+
+            $criteria = new Criteria();
+            $criteria->addFilter(new EqualsFilter('id', $orderId));
+            $criteria->addAssociation('transactions.stateMachineState');
+            $criteria->addAssociation('lineItems');
+            $criteria->addAssociation('customFields');
+            $criteria->addAssociation('lineItems.payload');
+            $criteria->addAssociation('lineItems.product.customFields');
+
+            $order = $this->orderRepository->search($criteria, $context)->first();
+
+            if (!$order) {
+                $this->logger->info('ABORTED Borrowing stock: Order not found', [
+                    'orderId' => $orderId,
+                ]);
+
+                return false;
+            }
+
+            if (!$order instanceof OrderEntity) {
+                $this->logger->info('ABORTED Borrowing stock: Order is not an instance of OrderEntity', [
+                    'orderId' => $orderId,
+                ]);
+
+                return false;
+            }
+
+            $orderCustomFields = $order->getCustomFields();
+
+            if (isset($orderCustomFields['os_subscriptions']['stock_borrowed']) && true === $orderCustomFields['os_subscriptions']['stock_borrowed']) {
+                $this->logger->info('ABORTED Borrowing stock 0: Stock was already borrowed', [
+                    'orderId' => $order->getId(),
+                    // 'orderCustomFields' => $orderCustomFields,
+                ]);
+
+                return false;
+            }
+
+            if (!isset($orderCustomFields['os_subscriptions']['order_type'])
+            or (isset($orderCustomFields['os_subscriptions']['order_type']) && 'initial' == $orderCustomFields['os_subscriptions']['order_type'])
+            ) {
+                $lineItems = $order->getLineItems();
+
+                if (!$lineItems) {
+                    $this->logger->info('ABORTED Borrowing stock 1: No line items found in order', [
+                        'orderId' => $order->getId(),
+                        // 'orderCustomFields' => $orderCustomFields,
+                    ]);
+
+                    return false;
+                }
+
+                foreach ($lineItems as $lineItem) {
+                    $lineItemPayload = $lineItem->getPayload();
+
+                    if (!isset($lineItemPayload['stock'])) {
+                        $this->logger->info('ABORTED Borrowing stock 2: No line items payload found in order', [
+                            'orderId' => $order->getId(),
+                            // 'orderCustomFields' => $orderCustomFields,
+                        ]);
+
+                        return false;
+                    }
+
+                    // check if the stock is below the required quantity
+                    if ($lineItemPayload['stock'] - $lineItem->getQuantity() < 0) {
+                        // calculate the number of items to borrow to get the stock to the required quantity - zero in the end
+                        // $numberOfItemsToBorrow = max(0, (int) $lineItem->getQuantity(), (int) $lineItemPayload['stock']); // - should we use this - fill up the stock only to zero?
+                        $numberOfItemsToBorrow = (int) $lineItem->getQuantity() - (int) $lineItemPayload['stock'];
+                    } else {
+                        // there's enough stock
+                        $this->logger->info('Borrowing stock NOT NEEDED', [
+                            'orderId' => $order->getId(),
+                            'lineItemQuantity' => (int) $lineItem->getQuantity(),
+                            'lineItemPayloadStock' => (int) $lineItemPayload['stock'],
+                        ]);
+
+                        return false;
+                    }
+
+                    // if the number of items to borrow is above 0
+                    if ($numberOfItemsToBorrow > 0) {
+                        $this->logger->info('CONTINUED Borrowing stock: Line items was found in order, and the product stock was below the required purchased quantity', [
+                            'orderId' => $order->getId(),
+                            'lineItemQuantity' => (int) $lineItem->getQuantity(),
+                            'lineItemPayloadStock' => (int) $lineItemPayload['stock'],
+                            'numberOfItemsToBorrow' => $numberOfItemsToBorrow,
+                        ]);
+
+                        $criteria = new Criteria();
+                        $criteria->addFilter(new EqualsFilter('id', $lineItem->getProductId()));
+                        $product = $this->productRepository->search($criteria, $context)->first();
+
+                        if ($product) {
+                            // Perform actions with the product
+                            $productCustomFields = $product->getCustomFields();
+
+                            if (!$productCustomFields or !isset($productCustomFields['mollie_payments_product_subscription_enabled'])) {
+                                $this->logger->info('ABORTED Borrowing stock 3: No product custom fields found', [
+                                    'product' => $product->getId(),
+                                    // 'productCustomFields' => $productCustomFields,
+                                ]);
+
+                                return false;
+                            }
+                            // Check if the product is a subscription product
+                            $isSubscriptionProduct = true === $productCustomFields['mollie_payments_product_subscription_enabled'] ? true : false;
+
+                            if (!$isSubscriptionProduct) {
+                                $this->logger->info('ABORTED Borrowing stock 4: Product is not subscription type', [
+                                    'product' => $product->getId(),
+                                ]);
+
+                                return false;
+                            }
+
+                            // Check if the product has a borrow product variant
+                            if (!isset($productCustomFields['mollie_payments_product_parent_buy_variant'])) {
+                                $this->logger->info('ABORTED Borrowing stock 5: Product has no borrowing variant', [
+                                    'product' => $product->getId(),
+                                    'orderCustomFields' => $orderCustomFields,
+                                ]);
+
+                                return false;
+                            }
+
+                            $borrowProductVariantId = $productCustomFields['mollie_payments_product_parent_buy_variant'];
+
+                            if (!$borrowProductVariantId) {
+                                return false;
+                            }
+
+                            // search for the borrow product variant
+                            $criteria = new Criteria([$borrowProductVariantId]);
+                            $criteria->addAssociation('customFields');
+
+                            $productBorrowVariant = $this->productRepository->search($criteria, $context)->first();
+
+                            // Check if the borrow product variant is available on stock
+                            if (!$productBorrowVariant or ($productBorrowVariant->getAvailableStock() < $numberOfItemsToBorrow)) {
+                                $this->logger->info('ABORTED Borrowing stock 6: Product borrowing variant doesnt exist or has not enough items on stock to borrow', [
+                                    'productBorrowVariant' => $productBorrowVariant->getId(),
+                                    'numberOfItemsToBorrow' => $numberOfItemsToBorrow,
+                                    'productBorrowVariantAvailableStock' => $productBorrowVariant->getAvailableStock(),
+                                    'productBorrowVariantStock' => $productBorrowVariant->getStock(),
+                                    // 'orderCustomFields' => $orderCustomFields,
+                                ]);
+
+                                return false;
+                            }
+
+                            // now swap the product stock like this; substract sthe stock from productBorrowVariant by the line item quantity and add it to the product
+
+                            // $productBorrowVariant->setAvailableStock($productBorrowVariant->getAvailableStock() - $lineItem->getQuantity());
+                            // $productBorrowVariant->setStock($productBorrowVariant->getStock() - $lineItem->getQuantity());
+                            // $product->setAvailableStock($product->getAvailableStock() + $lineItem->getQuantity());
+                            // $product->setStock($product->getStock() + $lineItem->getQuantity());
+
+                            $this->logger->info('PROCESSING Borrowing stock: Reducing stock from borrow product variant', [
+                                'lineItemId' => $lineItem->getId(),
+                                'productId' => $lineItem->getProductId(),
+                                'purchased' => $lineItem->getQuantity(),
+                                'productBorrowVariant' => $productBorrowVariant->getId(),
+                                'newStock' => $productBorrowVariant->getStock() - $numberOfItemsToBorrow,
+                                'oldStock' => $productBorrowVariant->getStock(),
+                                'numberOfItemsToBorrow' => $numberOfItemsToBorrow,
+                            ]);
+
+                            $this->logger->info('PROCCESING Borrowing stock: Adding stock to subscription variant', [
+                                'lineItemId' => $lineItem->getId(),
+                                'productId' => $lineItem->getProductId(),
+                                'quantity' => $lineItem->getQuantity(),
+                                'product' => $product->getId(),
+                                'newStock' => $product->getStock() + $numberOfItemsToBorrow,
+                                'oldStock' => $product->getStock(),
+                                'numberOfItemsBorrowed' => $numberOfItemsToBorrow,
+                            ]);
+
+                            // get context of the product borrow variant
+                            $productRepositoryContext = Context::createDefaultContext();
+
+                            // Update the product stock
+                            $this->productRepository->update(
+                                [
+                                    // update the product borrow variant
+                                    [
+                                        'id' => $productBorrowVariant->getId(),
+                                        'availableStock' => $productBorrowVariant->getAvailableStock() - $numberOfItemsToBorrow,
+                                        'stock' => $productBorrowVariant->getStock() - $numberOfItemsToBorrow,
+                                    ],
+                                    // update the product
+                                    [
+                                        'id' => $product->getId(),
+                                        'availableStock' => $product->getAvailableStock() + $numberOfItemsToBorrow,
+                                        'stock' => $product->getStock() + $numberOfItemsToBorrow,
+                                    ],
+                                ],
+                                $productRepositoryContext
+                            );
+
+                            $this->logger->info('PROCESSED Borrowing stock: Borrowed stock from borrow product variant');
+                            $this->logger->info('PROCESSED Borrowing stock: Added stock to subscription product variant');
+
+                            $orderCustomFields['os_subscriptions']['stock_borrowed'] = true;
+                            $orderCustomFields['os_subscriptions']['stock_borrowed_from'] = $productBorrowVariant->getId();
+                            $orderCustomFields['os_subscriptions']['stock_borrowed_to'] = $product->getId();
+                            $orderCustomFields['os_subscriptions']['stock_borrowed_amount'] = $numberOfItemsToBorrow;
+
+                            $this->orderRepository->update([
+                                [
+                                    'id' => $orderId,
+                                    'customFields' => $orderCustomFields,
+                                ],
+                            ], $context);
+
+                            $this->logger->info('PROCESSED Borrowing stock: Added borrowed stock data to order custom fields');
+                        }
+                    } else {
+                        $this->logger->info('ABORTED Borrowing stock 7: No need to borrow anything', [
+                            'orderId' => $order->getId(),
+                            'lineItemQuantity' => (int) $lineItem->getQuantity(),
+                            'lineItemPayloadStock' => (int) $lineItemPayload['stock'],
+                            'numberOfItemsToBorrow' => $numberOfItemsToBorrow,
+                            // 'orderCustomFields' => $orderCustomFields,
+                        ]);
+                    }
+                }
+
+                return true;
+            }
+
+            $this->logger->info('ABORTED Borrowing stock 8: Order is not of subscription initial type', [
+                'orderId' => $order,
+                // 'orderCustomFields' => $orderCustomFields,
+            ]);
+
+            return false;
+        } catch (\Exception $e) {
+            $this->logger->error('ABORTED Borrowing stock EXCEPTION:', [
+                'orderId' => $orderId ?? '',
+                'order' => $order ?? '',
+                'orderCustomFields' => $order->getCustomFields() ?? '',
+                'error' => $e->getMessage(),
+                'line' => $e->getLine(),
+            ]);
+
+            return false;
+        }
+    }
+}

--- a/src/Subscriber/RentProductLoadedSubscriber.php
+++ b/src/Subscriber/RentProductLoadedSubscriber.php
@@ -49,13 +49,13 @@ class RentProductLoadedSubscriber implements EventSubscriberInterface
             $combinedAvailableStock = 0;
 
             // Check if the product stock is available
-            $availableStock = $product->getAvailableStock();
+            // $availableStock = $product->getAvailableStock();
 
-            $combinedAvailableStock += $availableStock;
+            // if ($availableStock > 0) {
+            //     return;
+            // }
 
-            if ($availableStock > 0) {
-                return;
-            }
+            // $combinedAvailableStock += $availableStock;
 
             // Check if the product has a borrow product variant
             if (!isset($customFields['mollie_payments_product_parent_buy_variant'])) {
@@ -91,6 +91,11 @@ class RentProductLoadedSubscriber implements EventSubscriberInterface
 
             // Edit the max purchase of the product (not sure if this is from element template or standard shopware field)
             $product->setCalculatedMaxPurchase($combinedAvailableStock);
+
+            // set available stock to the combined available stock
+            $product->setAvailableStock($combinedAvailableStock);
+            // set stock to the combined available stock
+            $product->setStock($combinedAvailableStock);
 
             // Update the product custom fields
             $product->setCustomFields($customFields);


### PR DESCRIPTION
Implemented product borrowing via order transaction event.
Works only for 'initial' subscription order, when the wanna-be rented product is out of stock, and has selected variant to borrow stock from.
Stock replacement is only performed when order is paid, partially_paid, or authorized.

REVIEW: 
@bitsmyth 
in MollieSubscriptionHistorySubscriber->handleStockReductionForRenewals method I implemented skip if the order its initial or residual, since this should only work for renewals?