### PR TITLE
Update cancellation email templates with return instructions

### DIFF
--- a/src/Resources/views/email/de-AT/subscription/cancellation/html.twig
+++ b/src/Resources/views/email/de-AT/subscription/cancellation/html.twig
@@ -1,3 +1,39 @@
-<h2>Kündigung Ihres Abonnements</h2>
-
-<p>TODO: content...</p>
+<p>Hallo {{ customer->firstName }},</p>
+<br>
+<br>
+<p>vielen Dank, dass du die Retoure deines Mietprodukts angemeldet hast. Hier findest du alle wichtigen Infos für die Rückgabe:</p>
+<br>
+<br>
+<h3><strong>Vor dem Versand:</strong></h3>
+<p>Bitte achte darauf, dass alle Artikel vollständig, gereinigt und in einwandfreiem Zustand sind. So hilfst du uns, das Produkt rasch zu prüfen und wieder einsatzbereit zu machen.</p>
+<br>
+<br>
+<h3><strong>Adresse für die Rücksendung:</strong></h3>
+<p>
+    <strong>Babyrella</strong><br>
+    Waagner-Biro-Straße 20<br>
+    A-8020 Graz
+</p>
+<br>
+<br>
+<p>Die Versandkosten für die Rücksendung sind von dir zu tragen. Wir empfehlen dir, eine Versandart mit Sendungsverfolgung zu wählen. Alternativ kannst du das Produkt auch gerne persönlich in unserem Shop vorbeibringen.</p>
+<br>
+<br>
+<h3><strong>Wichtiger Hinweis:</strong></h3>
+<p>Lege der Rücksendung bitte ein kurzes Schreiben mit deinem Namen und deiner Adresse bei, damit wir die Rückgabe eindeutig zuordnen können.</p>
+<br>
+<br>
+<h3><strong>Was passiert nach Eingang des Produkts?</strong></h3>
+<p>Sobald das Mietprodukt bei uns eingetroffen ist, wird es auf Schäden und Vollständigkeit geprüft. Wenn alles in Ordnung ist, stoppen wir automatisch die weitere Mietzahlung. Sollte es Mängel oder fehlende Teile geben, setzen wir uns natürlich direkt mit dir in Verbindung.</p>
+<br>
+<br>
+<p>Du erhältst eine Bestätigung, sobald die Rückgabe erfolgreich abgeschlossen wurde.</p>
+<br>
+<br>
+<p>Wenn du noch Fragen hast, melde dich jederzeit gerne bei uns.</p>
+<br>
+<br>
+<p>
+    Liebe Grüße,<br>
+    <strong>deine Babyrellas</strong>
+</p>

--- a/src/Resources/views/email/de-AT/subscription/cancellation/plain.twig
+++ b/src/Resources/views/email/de-AT/subscription/cancellation/plain.twig
@@ -1,3 +1,29 @@
-Kündigung Ihres Abonnements
+Hallo {{ customer->firstName }},
 
-TODO: content...
+vielen Dank, dass du die Retoure deines Mietprodukts angemeldet hast. Hier findest du alle wichtigen Infos für die Rückgabe:
+
+Vor dem Versand:
+
+Bitte achte darauf, dass alle Artikel vollständig, gereinigt und in einwandfreiem Zustand sind. So hilfst du uns, das Produkt rasch zu prüfen und wieder einsatzbereit zu machen.
+
+Adresse für die Rücksendung:
+Babyrella
+Waagner-Biro-Straße 20
+A-8020 Graz
+
+Die Versandkosten für die Rücksendung sind von dir zu tragen. Wir empfehlen dir, eine Versandart mit Sendungsverfolgung zu wählen. Alternativ kannst du das Produkt auch gerne persönlich in unserem Shop vorbeibringen.
+
+Wichtiger Hinweis:
+
+Lege der Rücksendung bitte ein kurzes Schreiben mit deinem Namen und deiner Adresse bei, damit wir die Rückgabe eindeutig zuordnen können.
+
+Was passiert nach Eingang des Produkts?
+
+Sobald das Mietprodukt bei uns eingetroffen ist, wird es auf Schäden und Vollständigkeit geprüft. Wenn alles in Ordnung ist, stoppen wir automatisch die weitere Mietzahlung. Sollte es Mängel oder fehlende Teile geben, setzen wir uns natürlich direkt mit dir in Verbindung.
+
+Du erhältst eine Bestätigung, sobald die Rückgabe erfolgreich abgeschlossen wurde.
+
+Wenn du noch Fragen hast, melde dich jederzeit gerne bei uns.
+
+Liebe Grüße,
+deine Babyrellas

--- a/src/Resources/views/email/de-AT/subscription/cancellation/subject.twig
+++ b/src/Resources/views/email/de-AT/subscription/cancellation/subject.twig
@@ -1,1 +1,1 @@
-Kündigung Ihres Abonnements
+Deine Rücksendung – So geht’s weiter

--- a/src/Resources/views/email/de-DE/subscription/cancellation/html.twig
+++ b/src/Resources/views/email/de-DE/subscription/cancellation/html.twig
@@ -1,3 +1,39 @@
-<h2>Kündigung Ihres Abonnements</h2>
-
-<p>TODO: content...</p>
+<p>Hallo {{ customer->firstName }},</p>
+<br>
+<br>
+<p>vielen Dank, dass du die Retoure deines Mietprodukts angemeldet hast. Hier findest du alle wichtigen Infos für die Rückgabe:</p>
+<br>
+<br>
+<h3><strong>Vor dem Versand:</strong></h3>
+<p>Bitte achte darauf, dass alle Artikel vollständig, gereinigt und in einwandfreiem Zustand sind. So hilfst du uns, das Produkt rasch zu prüfen und wieder einsatzbereit zu machen.</p>
+<br>
+<br>
+<h3><strong>Adresse für die Rücksendung:</strong></h3>
+<p>
+    <strong>Babyrella</strong><br>
+    Waagner-Biro-Straße 20<br>
+    A-8020 Graz
+</p>
+<br>
+<br>
+<p>Die Versandkosten für die Rücksendung sind von dir zu tragen. Wir empfehlen dir, eine Versandart mit Sendungsverfolgung zu wählen. Alternativ kannst du das Produkt auch gerne persönlich in unserem Shop vorbeibringen.</p>
+<br>
+<br>
+<h3><strong>Wichtiger Hinweis:</strong></h3>
+<p>Lege der Rücksendung bitte ein kurzes Schreiben mit deinem Namen und deiner Adresse bei, damit wir die Rückgabe eindeutig zuordnen können.</p>
+<br>
+<br>
+<h3><strong>Was passiert nach Eingang des Produkts?</strong></h3>
+<p>Sobald das Mietprodukt bei uns eingetroffen ist, wird es auf Schäden und Vollständigkeit geprüft. Wenn alles in Ordnung ist, stoppen wir automatisch die weitere Mietzahlung. Sollte es Mängel oder fehlende Teile geben, setzen wir uns natürlich direkt mit dir in Verbindung.</p>
+<br>
+<br>
+<p>Du erhältst eine Bestätigung, sobald die Rückgabe erfolgreich abgeschlossen wurde.</p>
+<br>
+<br>
+<p>Wenn du noch Fragen hast, melde dich jederzeit gerne bei uns.</p>
+<br>
+<br>
+<p>
+    Liebe Grüße,<br>
+    <strong>deine Babyrellas</strong>
+</p>

--- a/src/Resources/views/email/de-DE/subscription/cancellation/plain.twig
+++ b/src/Resources/views/email/de-DE/subscription/cancellation/plain.twig
@@ -1,3 +1,29 @@
-Kündigung Ihres Abonnements
+Hallo {{ customer->firstName }},
 
-TODO: content...
+vielen Dank, dass du die Retoure deines Mietprodukts angemeldet hast. Hier findest du alle wichtigen Infos für die Rückgabe:
+
+Vor dem Versand:
+
+Bitte achte darauf, dass alle Artikel vollständig, gereinigt und in einwandfreiem Zustand sind. So hilfst du uns, das Produkt rasch zu prüfen und wieder einsatzbereit zu machen.
+
+Adresse für die Rücksendung:
+Babyrella
+Waagner-Biro-Straße 20
+A-8020 Graz
+
+Die Versandkosten für die Rücksendung sind von dir zu tragen. Wir empfehlen dir, eine Versandart mit Sendungsverfolgung zu wählen. Alternativ kannst du das Produkt auch gerne persönlich in unserem Shop vorbeibringen.
+
+Wichtiger Hinweis:
+
+Lege der Rücksendung bitte ein kurzes Schreiben mit deinem Namen und deiner Adresse bei, damit wir die Rückgabe eindeutig zuordnen können.
+
+Was passiert nach Eingang des Produkts?
+
+Sobald das Mietprodukt bei uns eingetroffen ist, wird es auf Schäden und Vollständigkeit geprüft. Wenn alles in Ordnung ist, stoppen wir automatisch die weitere Mietzahlung. Sollte es Mängel oder fehlende Teile geben, setzen wir uns natürlich direkt mit dir in Verbindung.
+
+Du erhältst eine Bestätigung, sobald die Rückgabe erfolgreich abgeschlossen wurde.
+
+Wenn du noch Fragen hast, melde dich jederzeit gerne bei uns.
+
+Liebe Grüße,
+deine Babyrellas

--- a/src/Resources/views/email/de-DE/subscription/cancellation/subject.twig
+++ b/src/Resources/views/email/de-DE/subscription/cancellation/subject.twig
@@ -1,1 +1,1 @@
-Kündigung Ihres Abonnements
+Deine Rücksendung – So geht’s weiter


### PR DESCRIPTION
Revised German email templates to replace subscription cancellation content with detailed product return instructions. Updates include personalized greetings, return address, shipping guidelines, and process explanations in both plain text and HTML formats for DE and AT locales.

https://trello.com/b/ZGFF8POq/babyrellaat-3