### PR TITLE
minor fixes

### DIFF
--- a/src/Checkout/Cart/ResidualCartProcessor.php
+++ b/src/Checkout/Cart/ResidualCartProcessor.php
@@ -33,15 +33,24 @@ class ResidualCartProcessor implements CartDataCollectorInterface, CartProcessor
      */
     public function process(CartDataCollection $data, Cart $original, Cart $toCalculate, SalesChannelContext $context, CartBehavior $behavior): void
     {
+        $hasResidualProducts = false;
+
         foreach ($original->getLineItems() as $lineItem) {
             if ($lineItem->getType() === SubscriptionLineItem::PRODUCT_RESIDUAL_TYPE ||
                 $lineItem->getType() === SubscriptionLineItem::DISCOUNT_RESIDUAL_TYPE) {
+                $hasResidualProducts = true;
+
                 $toCalculate->add($lineItem);
                 $toCalculate->markModified();
             }
         }
 
         $this->removeInvalidResidualDiscounts($toCalculate);
+
+        # disable loyalty points
+        if ($hasResidualProducts) {
+            $context->getCustomer()->removeExtension('loyaltyPoints');
+        }
     }
 
     /**

--- a/src/Controller/Storefront/Account/AccountController.php
+++ b/src/Controller/Storefront/Account/AccountController.php
@@ -209,8 +209,8 @@ class AccountController extends AbstractStoreFrontController
     {
         $discountLineItem = new LineItem(Uuid::randomHex(), SubscriptionLineItem::DISCOUNT_RESIDUAL_TYPE);
 
-        $discountLineItem->setLabel('Restkauf Rabatt auf Abonnement');
-        $discountLineItem->setDescription('Restkauf Rabatt auf Abonnement');
+        $discountLineItem->setLabel('Restkauf Rabatt auf Mietprodukt');
+        $discountLineItem->setDescription('Restkauf Rabatt auf Mietprodukt');
         $discountLineItem->setGood(false);
         $discountLineItem->setStackable(false);
         $discountLineItem->setRemovable(true);

--- a/src/Resources/views/email/de-AT/subscription/cancellation/html.twig
+++ b/src/Resources/views/email/de-AT/subscription/cancellation/html.twig
@@ -1,39 +1,118 @@
-<p>Hallo {{ customer->firstName }},</p>
-<br>
-<br>
-<p>vielen Dank, dass du die Retoure deines Mietprodukts angemeldet hast. Hier findest du alle wichtigen Infos für die Rückgabe:</p>
-<br>
-<br>
-<h3><strong>Vor dem Versand:</strong></h3>
-<p>Bitte achte darauf, dass alle Artikel vollständig, gereinigt und in einwandfreiem Zustand sind. So hilfst du uns, das Produkt rasch zu prüfen und wieder einsatzbereit zu machen.</p>
-<br>
-<br>
-<h3><strong>Adresse für die Rücksendung:</strong></h3>
-<p>
-    <strong>Babyrella</strong><br>
-    Waagner-Biro-Straße 20<br>
-    A-8020 Graz
-</p>
-<br>
-<br>
-<p>Die Versandkosten für die Rücksendung sind von dir zu tragen. Wir empfehlen dir, eine Versandart mit Sendungsverfolgung zu wählen. Alternativ kannst du das Produkt auch gerne persönlich in unserem Shop vorbeibringen.</p>
-<br>
-<br>
-<h3><strong>Wichtiger Hinweis:</strong></h3>
-<p>Lege der Rücksendung bitte ein kurzes Schreiben mit deinem Namen und deiner Adresse bei, damit wir die Rückgabe eindeutig zuordnen können.</p>
-<br>
-<br>
-<h3><strong>Was passiert nach Eingang des Produkts?</strong></h3>
-<p>Sobald das Mietprodukt bei uns eingetroffen ist, wird es auf Schäden und Vollständigkeit geprüft. Wenn alles in Ordnung ist, stoppen wir automatisch die weitere Mietzahlung. Sollte es Mängel oder fehlende Teile geben, setzen wir uns natürlich direkt mit dir in Verbindung.</p>
-<br>
-<br>
-<p>Du erhältst eine Bestätigung, sobald die Rückgabe erfolgreich abgeschlossen wurde.</p>
-<br>
-<br>
-<p>Wenn du noch Fragen hast, melde dich jederzeit gerne bei uns.</p>
-<br>
-<br>
-<p>
-    Liebe Grüße,<br>
-    <strong>deine Babyrellas</strong>
-</p>
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+
+<head>
+    <title></title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+        body {
+            margin: 0;
+            padding: 0;
+            -webkit-text-size-adjust: 100%;
+            -ms-text-size-adjust: 100%;
+            color: #43423E;
+            background-color: #f5f1e9;
+            font-family: Poppins, sans-serif;
+        }
+
+        table,
+        td {
+            border-collapse: collapse;
+            mso-table-lspace: 0;
+            mso-table-rspace: 0;
+        }
+
+        img {
+            border: 0;
+            height: auto;
+            line-height: 100%;
+            outline: none;
+            text-decoration: none;
+            -ms-interpolation-mode: bicubic;
+        }
+
+        p {
+            display: block;
+            margin: 13px 0;
+            font-size: 14px;
+        }
+
+        h2 {
+            font-size: 22px;
+            font-weight: 800;
+        }
+
+        h3 {
+            font-size: 18px;
+            font-weight: 700;
+        }
+    </style>
+    <!--[if mso]>
+    <noscript>
+        <xml>
+            <o:OfficeDocumentSettings>
+                <o:AllowPNG/>
+                <o:PixelsPerInch>96</o:PixelsPerInch>
+            </o:OfficeDocumentSettings>
+        </xml>
+    </noscript>
+    <![endif]-->
+</head>
+
+<body>
+<!--[if mso]>
+<table width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#f5f1e9">
+    <tr>
+        <td align="center">
+<![endif]-->
+<div style="background-color:#f5f1e9; width:100%;">
+    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="max-width:600px; width:100%; background-color:#ffffff; padding:20px; border-radius:8px;">
+        <tbody>
+        <tr>
+            <td style="direction:ltr; text-align:left;">
+                <h2>Hallo {{ customer->firstName }},</h2>
+                <p>vielen Dank, dass du die Retoure deines Mietprodukts angemeldet hast. Hier findest du alle wichtigen Infos für die Rückgabe:</p>
+
+                <h3>Vor dem Versand:</h3>
+                <p>Bitte achte darauf, dass alle Artikel vollständig, gereinigt und in einwandfreiem Zustand sind. So hilfst du uns, das Produkt rasch zu prüfen und wieder einsatzbereit zu machen.</p>
+
+                <h3>Adresse für die Rücksendung:</h3>
+                <p>
+                    <strong>Babyrella</strong><br>
+                    Waagner-Biro-Straße 20<br>
+                    A-8020 Graz
+                </p>
+
+                <p>Die Versandkosten für die Rücksendung sind von dir zu tragen. Wir empfehlen dir, eine Versandart mit Sendungsverfolgung zu wählen. Alternativ kannst du das Produkt auch gerne persönlich in unserem Shop vorbeibringen.</p>
+
+                <h3>Wichtiger Hinweis:</h3>
+                <p>Lege der Rücksendung bitte ein kurzes Schreiben mit deinem Namen und deiner Adresse bei, damit wir die Rückgabe eindeutig zuordnen können.</p>
+
+                <h3>Was passiert nach Eingang des Produkts?</h3>
+                <p>Sobald das Mietprodukt bei uns eingetroffen ist, wird es auf Schäden und Vollständigkeit geprüft. Wenn alles in Ordnung ist, stoppen wir automatisch die weitere Mietzahlung. Sollte es Mängel oder fehlende Teile geben, setzen wir uns natürlich direkt mit dir in Verbindung.</p>
+
+                <p>Du erhältst eine Bestätigung, sobald die Rückgabe erfolgreich abgeschlossen wurde.</p>
+
+                <p>Wenn du noch Fragen hast, melde dich jederzeit gerne bei uns.</p>
+
+                <p>
+                    Liebe Grüße,<br>
+                    <strong>deine Babyrellas</strong>
+                </p>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+<!--[if mso]>
+</td>
+</tr>
+</table>
+<![endif]-->
+</body>
+
+</html>

--- a/src/Resources/views/email/de-DE/subscription/cancellation/html.twig
+++ b/src/Resources/views/email/de-DE/subscription/cancellation/html.twig
@@ -1,39 +1,118 @@
-<p>Hallo {{ customer->firstName }},</p>
-<br>
-<br>
-<p>vielen Dank, dass du die Retoure deines Mietprodukts angemeldet hast. Hier findest du alle wichtigen Infos für die Rückgabe:</p>
-<br>
-<br>
-<h3><strong>Vor dem Versand:</strong></h3>
-<p>Bitte achte darauf, dass alle Artikel vollständig, gereinigt und in einwandfreiem Zustand sind. So hilfst du uns, das Produkt rasch zu prüfen und wieder einsatzbereit zu machen.</p>
-<br>
-<br>
-<h3><strong>Adresse für die Rücksendung:</strong></h3>
-<p>
-    <strong>Babyrella</strong><br>
-    Waagner-Biro-Straße 20<br>
-    A-8020 Graz
-</p>
-<br>
-<br>
-<p>Die Versandkosten für die Rücksendung sind von dir zu tragen. Wir empfehlen dir, eine Versandart mit Sendungsverfolgung zu wählen. Alternativ kannst du das Produkt auch gerne persönlich in unserem Shop vorbeibringen.</p>
-<br>
-<br>
-<h3><strong>Wichtiger Hinweis:</strong></h3>
-<p>Lege der Rücksendung bitte ein kurzes Schreiben mit deinem Namen und deiner Adresse bei, damit wir die Rückgabe eindeutig zuordnen können.</p>
-<br>
-<br>
-<h3><strong>Was passiert nach Eingang des Produkts?</strong></h3>
-<p>Sobald das Mietprodukt bei uns eingetroffen ist, wird es auf Schäden und Vollständigkeit geprüft. Wenn alles in Ordnung ist, stoppen wir automatisch die weitere Mietzahlung. Sollte es Mängel oder fehlende Teile geben, setzen wir uns natürlich direkt mit dir in Verbindung.</p>
-<br>
-<br>
-<p>Du erhältst eine Bestätigung, sobald die Rückgabe erfolgreich abgeschlossen wurde.</p>
-<br>
-<br>
-<p>Wenn du noch Fragen hast, melde dich jederzeit gerne bei uns.</p>
-<br>
-<br>
-<p>
-    Liebe Grüße,<br>
-    <strong>deine Babyrellas</strong>
-</p>
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+
+<head>
+    <title></title>
+    <!--[if !mso]><!-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <!--<![endif]-->
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+        body {
+            margin: 0;
+            padding: 0;
+            -webkit-text-size-adjust: 100%;
+            -ms-text-size-adjust: 100%;
+            color: #43423E;
+            background-color: #f5f1e9;
+            font-family: Poppins, sans-serif;
+        }
+
+        table,
+        td {
+            border-collapse: collapse;
+            mso-table-lspace: 0;
+            mso-table-rspace: 0;
+        }
+
+        img {
+            border: 0;
+            height: auto;
+            line-height: 100%;
+            outline: none;
+            text-decoration: none;
+            -ms-interpolation-mode: bicubic;
+        }
+
+        p {
+            display: block;
+            margin: 13px 0;
+            font-size: 14px;
+        }
+
+        h2 {
+            font-size: 22px;
+            font-weight: 800;
+        }
+
+        h3 {
+            font-size: 18px;
+            font-weight: 700;
+        }
+    </style>
+    <!--[if mso]>
+    <noscript>
+        <xml>
+            <o:OfficeDocumentSettings>
+                <o:AllowPNG/>
+                <o:PixelsPerInch>96</o:PixelsPerInch>
+            </o:OfficeDocumentSettings>
+        </xml>
+    </noscript>
+    <![endif]-->
+</head>
+
+<body>
+<!--[if mso]>
+<table width="100%" border="0" cellspacing="0" cellpadding="0" bgcolor="#f5f1e9">
+    <tr>
+        <td align="center">
+<![endif]-->
+<div style="background-color:#f5f1e9; width:100%;">
+    <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="max-width:600px; width:100%; background-color:#ffffff; padding:20px; border-radius:8px;">
+        <tbody>
+        <tr>
+            <td style="direction:ltr; text-align:left;">
+                <h2>Hallo {{ customer->firstName }},</h2>
+                <p>vielen Dank, dass du die Retoure deines Mietprodukts angemeldet hast. Hier findest du alle wichtigen Infos für die Rückgabe:</p>
+
+                <h3>Vor dem Versand:</h3>
+                <p>Bitte achte darauf, dass alle Artikel vollständig, gereinigt und in einwandfreiem Zustand sind. So hilfst du uns, das Produkt rasch zu prüfen und wieder einsatzbereit zu machen.</p>
+
+                <h3>Adresse für die Rücksendung:</h3>
+                <p>
+                    <strong>Babyrella</strong><br>
+                    Waagner-Biro-Straße 20<br>
+                    A-8020 Graz
+                </p>
+
+                <p>Die Versandkosten für die Rücksendung sind von dir zu tragen. Wir empfehlen dir, eine Versandart mit Sendungsverfolgung zu wählen. Alternativ kannst du das Produkt auch gerne persönlich in unserem Shop vorbeibringen.</p>
+
+                <h3>Wichtiger Hinweis:</h3>
+                <p>Lege der Rücksendung bitte ein kurzes Schreiben mit deinem Namen und deiner Adresse bei, damit wir die Rückgabe eindeutig zuordnen können.</p>
+
+                <h3>Was passiert nach Eingang des Produkts?</h3>
+                <p>Sobald das Mietprodukt bei uns eingetroffen ist, wird es auf Schäden und Vollständigkeit geprüft. Wenn alles in Ordnung ist, stoppen wir automatisch die weitere Mietzahlung. Sollte es Mängel oder fehlende Teile geben, setzen wir uns natürlich direkt mit dir in Verbindung.</p>
+
+                <p>Du erhältst eine Bestätigung, sobald die Rückgabe erfolgreich abgeschlossen wurde.</p>
+
+                <p>Wenn du noch Fragen hast, melde dich jederzeit gerne bei uns.</p>
+
+                <p>
+                    Liebe Grüße,<br>
+                    <strong>deine Babyrellas</strong>
+                </p>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+<!--[if mso]>
+</td>
+</tr>
+</table>
+<![endif]-->
+</body>
+
+</html>

--- a/src/Resources/views/storefront/page/account/subscriptions/subscription-item.html.twig
+++ b/src/Resources/views/storefront/page/account/subscriptions/subscription-item.html.twig
@@ -28,10 +28,29 @@
     {# disabled #}
 {% endblock %}
 
+{% block page_account_subscriptions_item_context_menu_col %}
+    {% if subscription.status == "canceled" %}
+        {# disabled #}
+    {% else %}
+        {{ parent() }}
+    {% endif %}
+{% endblock %}
+
+{% block page_account_mollie_subscriptions_item_cancel_until %}
+    {# disabled #}
+{% endblock %}
+
+{% block page_account_mollie_subscriptions_item_next_payment %}
+    {% if subscription.status == "canceled" %}
+        {# disabled #}
+    {% else %}
+        {{ parent() }}
+    {% endif %}
+{% endblock %}
+
 {% block page_account_mollie_subscriptions_item_overview %}
     {{ parent() }}
 
-    {% set metadata = subscription.get('metadata') %}
     <div class="order-wrapper">
         <div class="order-item-header">
             <div class="row flex-wrap">
@@ -42,7 +61,7 @@
                     <p><strong>Rücksendung erhalten:</strong> {{ attribute(metadata, 'cancellation_reviewed_at')|date('d.m.Y H:i', 'Europe/Vienna') }}</p>
                 {% endif %}
                 <div class='row flex-wrap' style="padding-top: 12px;padding-left:-12px;">
-                    {% if metadata['cancellation_initialized_at'] is not defined or metadata['cancellation_initialized_at'] is empty %}
+                    {% if (metadata['cancellation_initialized_at'] is not defined or metadata['cancellation_initialized_at'] is empty) and subscription.status != 'canceled' %}
                         <button type="button" class="btn btn-primary col-6" data-bs-toggle="modal" data-bs-target="#exampleModal">
                             Rücksendung anfordern
                         </button>
@@ -61,8 +80,8 @@
                                                 Bitte sende dein gemietetes Produkt an folgende Adresse zurück:
                                                 <br>
                                                 <br>
-                                                Babyrella
-                                                Waagner-Biro-Straße 20
+                                                Babyrella <br>
+                                                Waagner-Biro-Straße 20 <br>
                                                 A-8020 Graz
                                                 <br>
                                                 <br>

--- a/src/Resources/views/storefront/page/account/subscriptions/subscription-item.html.twig
+++ b/src/Resources/views/storefront/page/account/subscriptions/subscription-item.html.twig
@@ -74,7 +74,9 @@
                                         </div>
                                         <div class="modal-body">
                                             <p>
-                                                Vor der Rücksendung ist darauf zu achten, dass alle Artikel gereinigt, geputzt und vollständig zurückgesendet werden. Die Kosten für die Rücksendung sind selbst zu tragen. Alternativ kann das Mietprodukt auch direkt in unserem Shop abgegeben werden.
+                                                Vor der Rücksendung ist darauf zu achten, dass alle Artikel gereinigt, geputzt und vollständig zurückgesendet werden. Die Kosten für die Rücksendung sind selbst zu tragen. <br>
+                                                <br>
+                                                Alternativ kann das Mietprodukt auch direkt in unserem Shop abgegeben werden.
                                                 <br>
                                                 <br>
                                                 Bitte sende dein gemietetes Produkt an folgende Adresse zurück:


### PR DESCRIPTION
- disabled elements for `/subscriptions` within account
- updated wordings and texts
- disabled loyaltypoints for residual purchases
- updated emails using customers template "design"

## References
https://trello.com/c/RggZgbvf/196-button-r%C3%BCcksendung-anfordern-is-available-also-after-buyout
https://trello.com/c/yTa1CMPe/199-customer-overwiew-dashboads-please-remove-k%C3%BCndbar-bis
https://trello.com/c/YTN8luQ6/190-e-mail-when-customer-announces-a-rent-retun
https://trello.com/c/5sJ7wMDg/198-treuepunkte-can-not-be-applied-on-buyout
https://trello.com/c/ll7sgfAu/197-shopware-customer-rent-dashboard-please-hide-if-nothing-to-show
https://trello.com/c/X9tcMPZb/195-wording


> [!IMPORTANT]
> We need to reinstall the plugin again as the html changed wich is actually set in email templates during installation process. Otherwise the change will not take effect.