### PR TITLE
Fix/stock borrow purchase variant

### DIFF
--- a/src/Subscriber/MollieSubscriptionHistorySubscriber.php
+++ b/src/Subscriber/MollieSubscriptionHistorySubscriber.php
@@ -98,6 +98,12 @@ class MollieSubscriptionHistorySubscriber implements EventSubscriberInterface
                 $quantity = $lineItem->getQuantity();
                 $productStock = $lineItem->getPayload()['stock'];
 
+                $this->logger->info('MollieSubscriptionHistorySubscriber: stock increase PROCESS', [
+                    'productId' => $lineItem->getProductId(),
+                    'quantityBefore' => $productStock + $quantity,
+                    'newQuantity' => $productStock,
+                ]);
+
                 // persist the stock storage, so no changes will take effect
                 $this->stockStorage->alter(
                     [new StockAlteration($lineItem->getId(), $lineItem->getProductId(), $productStock + $quantity, $productStock)],


### PR DESCRIPTION
borrow only from purchase variant, add nothing to rent variant
the available stock problem going up for rent variant should now be dealt from POS side, when the order is picked.